### PR TITLE
/photos/:titleページを追加

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -24,6 +24,9 @@ app.route("/users", usersRouter);
 app.route("/photos", photosRouter);
 
 app.notFound((c) => {
+  // 最後が/で終わる404の場合は/なしにリダイレクト
+  if(c.req.path.endsWith('/')) return c.redirect(c.req.path.slice(0, -1));
+
   return c.html(
     html`
       <!doctype html>

--- a/src/routes/photos.js
+++ b/src/routes/photos.js
@@ -6,4 +6,9 @@ app.get("/", (c) => {
   return c.text("Some photos");
 });
 
+app.get('/:title', (c) => {
+  const title = c.req.param('title');
+  return c.text(title);
+});
+
 module.exports = app;


### PR DESCRIPTION
* `photos/:title`にアクセスすると`:title`の内容が表示されるように
* `/users/`や`/photos/`のように最後が`/`で終わるパスで404が返ってくるのを防ぐため、最後が`/`のパスで404の場合は`/`を除いたパスにリダイレクトするよう`app.notFound`(`app.js`)に追記

`/photos/`にアクセスした時404が返ってくるのが気になったので修正してみました。
練習問題のためマージは不要です。